### PR TITLE
Add CSV export command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    onesignal-ruby (0.2.0)
+    onesignal-ruby (0.3.0)
       activesupport (~> 5.0, >= 5.0.0)
       faraday (~> 0.15, >= 0.15.4)
       simple_command (~> 0, >= 0.0.9)
@@ -37,7 +37,7 @@ GEM
     i18n (1.5.1)
       concurrent-ruby (~> 1.0)
     minitest (5.11.3)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     public_suffix (3.0.3)
     rake (10.5.0)
     rspec (3.8.0)
@@ -56,7 +56,7 @@ GEM
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     safe_yaml (1.0.4)
-    simple_command (0.0.9)
+    simple_command (0.1.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -82,4 +82,4 @@ DEPENDENCIES
   webmock (~> 3.4)
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/fixtures/vcr_cassettes/os-csv-export.yml
+++ b/fixtures/vcr_cassettes/os-csv-export.yml
@@ -1,0 +1,135 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://onesignal.com/api/v1/players/csv_export?app_id=test
+    body:
+      encoding: UTF-8
+      string: '{"app_id":"test"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic ZjI3NDAwY2ItNTM1Yy00OTkwLWE1OTAtNzI0ZjdmNTg1ZTlj
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Sep 2019 14:33:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d10f3912512be2fb143a35a8fb1af30331568730781; expires=Wed, 16-Sep-20
+        14:33:01 GMT; path=/; domain=.onesignal.com; HttpOnly
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - b5baa4c3-9884-4a26-ad57-9695fe9c85a4
+      Access-Control-Allow-Headers:
+      - SDK-Version
+      Etag:
+      - W/"7965e366a680d7fa0c3b52547dfd736a"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.169620'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 5.3.7
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 517bcaf63e2ed45b-HAM
+    body:
+      encoding: ASCII-8BIT
+      string: '{"csv_file_url":"https://onesignal.s3.amazonaws.com/csv_exports/test/users_abc123.csv.gz"}'
+    http_version: 
+  recorded_at: Tue, 17 Sep 2019 14:33:01 GMT
+- request:
+    method: post
+    uri: https://onesignal.com/api/v1/players/csv_export?app_id=test
+    body:
+      encoding: UTF-8
+      string: '{"app_id":"test","last_active_since":"1568419200"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic ZjI3NDAwY2ItNTM1Yy00OTkwLWE1OTAtNzI0ZjdmNTg1ZTlj
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Sep 2019 14:33:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d10f3912512be2fb143a35a8fb1af30331568730781; expires=Wed, 16-Sep-20
+        14:33:01 GMT; path=/; domain=.onesignal.com; HttpOnly
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - b5baa4c3-9884-4a26-ad57-9695fe9c85a4
+      Access-Control-Allow-Headers:
+      - SDK-Version
+      Etag:
+      - W/"7965e366a680d7fa0c3b52547dfd736a"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.169620'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 5.3.7
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 517bcaf63e2ed45b-HAM
+    body:
+      encoding: ASCII-8BIT
+      string: '{"csv_file_url":"https://onesignal.s3.amazonaws.com/csv_exports/test/users_def456.csv.gz"}'
+    http_version: 
+  recorded_at: Tue, 17 Sep 2019 14:33:01 GMT
+recorded_with: VCR 4.0.0

--- a/lib/onesignal.rb
+++ b/lib/onesignal.rb
@@ -41,6 +41,13 @@ module OneSignal
       JSON.parse(fetched.body)['players'].map { |player| Responses::Player.from_json player }
     end
 
+    def csv_export params = {}
+      return unless OneSignal.config.active
+
+      fetched = Commands::CsvExport.call params
+      Responses::CsvExport.from_json fetched.body
+    end
+
     def config
       @config ||= Configuration.new
     end

--- a/lib/onesignal/client.rb
+++ b/lib/onesignal/client.rb
@@ -35,6 +35,14 @@ module OneSignal
       get "players/#{player_id}"
     end
 
+    def csv_export extra_fields: nil, last_active_since: nil, segment_name: nil
+      params = {}
+      params[:extra_fields] = extra_fields if extra_fields
+      params[:last_active_since] = last_active_since.to_i.to_s if last_active_since
+      params[:segment_name] = segment_name if segment_name
+      post "players/csv_export?app_id=#{@app_id}", params
+    end
+
     private
 
     def create_body payload

--- a/lib/onesignal/commands/csv_export.rb
+++ b/lib/onesignal/commands/csv_export.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module OneSignal
+  module Commands
+    class CsvExport < BaseCommand
+      def initialize params
+        @params = params || {}
+      end
+
+      def call
+        client.csv_export @params
+      end
+    end
+  end
+end

--- a/lib/onesignal/responses/base_response.rb
+++ b/lib/onesignal/responses/base_response.rb
@@ -6,7 +6,12 @@ module OneSignal
       def initialize attributes = {}
         @attributes = attributes.deep_symbolize_keys
                                 .keep_if { |k, _v| self.class::ATTRIBUTES_WHITELIST.include?(k.to_sym) }
-        self.class.attr_reader(*self.class::ATTRIBUTES_WHITELIST)
+
+        self.class::ATTRIBUTES_WHITELIST.each do |attribute|
+          self.class.send(:define_method, attribute) do
+            @attributes[attribute]
+          end
+        end
       end
     end
   end

--- a/lib/onesignal/responses/csv_export.rb
+++ b/lib/onesignal/responses/csv_export.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module OneSignal
+  module Responses
+    # Example JSON
+    # {
+    #   "csv_file_url": "https://onesignal.s3.amazonaws.com/csv_exports/test/users_abc123.csv.gz"
+    # }
+    class CsvExport < BaseResponse
+      ATTRIBUTES_WHITELIST = %i[csv_file_url].freeze
+
+      def self.from_json json
+        body = json.is_a?(String) ? JSON.parse(json) : json
+        new(body)
+      end
+    end
+  end
+end

--- a/spec/api_calls_spec.rb
+++ b/spec/api_calls_spec.rb
@@ -51,4 +51,30 @@ describe 'Live API Testing', remote: true do
       expect(player.id).to eq @player_id
     end
   end
+
+  context 'with keys' do
+    around do |example|
+      OneSignal.config.app_id = app_id
+      OneSignal.config.api_key = api_key
+      example.run
+      OneSignal.config.app_id = nil
+      OneSignal.config.api_key = nil
+    end
+
+    it 'fetches CSV export data' do
+      VCR.use_cassette('os-csv-export') do
+        response = OneSignal.csv_export
+        expect(response).to be_instance_of OneSignal::Responses::CsvExport
+        expect(response.csv_file_url).to eq 'https://onesignal.s3.amazonaws.com/csv_exports/test/users_abc123.csv.gz'
+      end
+    end
+
+    it 'fetches CSV export data with params' do
+      VCR.use_cassette('os-csv-export', match_requests_on: [:body_as_json]) do
+        response = OneSignal.csv_export last_active_since: Time.at(1568419200)
+        expect(response).to be_instance_of OneSignal::Responses::CsvExport
+        expect(response.csv_file_url).to eq 'https://onesignal.s3.amazonaws.com/csv_exports/test/users_def456.csv.gz'
+      end
+    end
+  end
 end

--- a/spec/onesignal/responses/csv_export_spec.rb
+++ b/spec/onesignal/responses/csv_export_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OneSignal::Responses::CsvExport do
+  let(:json) do
+    <<~JSON
+      {
+        "csv_file_url": "https://some.csv.gz"
+      }
+    JSON
+  end
+
+  it 'has csv_file_url attribute' do
+    expect(described_class.from_json(json).csv_file_url).to eq "https://some.csv.gz"
+  end
+end


### PR DESCRIPTION
Adds:

```ruby
OneSignal.csv_export last_active_since: Time.now
```

https://documentation.onesignal.com/reference#csv-export

I had to change the attribute magic in **lib/onesignal/responses/base_response.rb** as it wasn't working as expected. It was previously creating `attr_accessor`s but not assigning the variable.