### PR TITLE
Remove deprecation warning on Ruby 2.7

### DIFF
--- a/lib/onesignal/notification/contents.rb
+++ b/lib/onesignal/notification/contents.rb
@@ -10,7 +10,7 @@ module OneSignal
 
       def initialize en:, **content
         @content = content.merge(en: en)
-        create_readers @content
+        create_readers **@content
       end
     end
   end

--- a/lib/onesignal/notification/headings.rb
+++ b/lib/onesignal/notification/headings.rb
@@ -10,7 +10,7 @@ module OneSignal
 
       def initialize en:, **headings
         @headings = headings.merge(en: en)
-        create_readers @headings
+        create_readers **@headings
       end
     end
   end


### PR DESCRIPTION
Remove deprecation warning on Ruby 2.7.x

```
/home/circleci/repo/vendor/bundle/ruby/2.7.0/bundler/gems/onesignal-ruby-5426910d3658/lib/onesignal/notification/headings.rb:13: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/circleci/repo/vendor/bundle/ruby/2.7.0/bundler/gems/onesignal-ruby-5426910d3658/lib/onesignal/auto_map.rb:5: warning: The called method `create_readers' is defined here
/home/circleci/repo/vendor/bundle/ruby/2.7.0/bundler/gems/onesignal-ruby-5426910d3658/lib/onesignal/notification/contents.rb:13: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/circleci/repo/vendor/bundle/ruby/2.7.0/bundler/gems/onesignal-ruby-5426910d3658/lib/onesignal/auto_map.rb:5: warning: The called method `create_readers' is defined here
```