### PR TITLE
Add support for OneSignal action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ attachments = OneSignal::Attachments.new(
 OneSignal::Notification.new(attachments: attachments)
 ```
 
+### Buttons
+You can add interactive buttons to a notification. See https://documentation.onesignal.com/docs/action-buttons for more details.
+
+```ruby
+buttons = OneSignal::Buttons.new(
+    buttons: [{id: 'option_a', text: 'Option A' }, {id: 'option_b', text: 'Option B' }]
+)
+
+OneSignal::Notification.new(buttons: buttons)
+```
+
 ### Fetch players
 You can fetch all players and devices with a simple method.
 

--- a/lib/onesignal/buttons.rb
+++ b/lib/onesignal/buttons.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module OneSignal
+  class Buttons
+    attr_reader :buttons
+
+    def initialize buttons: nil
+      @buttons = buttons
+    end
+
+    def as_json options = nil
+      {
+        'buttons' => @buttons.as_json(options),
+      }
+    end
+  end
+end

--- a/lib/onesignal/notification.rb
+++ b/lib/onesignal/notification.rb
@@ -6,7 +6,7 @@ require 'onesignal/notification/headings'
 module OneSignal
   class Notification
     attr_reader :contents, :headings, :template_id, :included_segments, :excluded_segments,
-                :included_targets, :send_after, :attachments, :sounds
+                :included_targets, :send_after, :attachments, :sounds, :buttons
 
     def initialize **params
       unless params.include?(:contents) || params.include?(:template_id)
@@ -23,6 +23,7 @@ module OneSignal
       @attachments       = params[:attachments]
       @filters           = params[:filters]
       @sounds            = params[:sounds]
+      @buttons           = params[:buttons]
     end
 
     def as_json options = {}
@@ -30,6 +31,7 @@ module OneSignal
         .except('attachments', 'sounds', 'included_targets')
         .merge(@attachments&.as_json(options) || {})
         .merge(@sounds&.as_json(options) || {})
+        .merge(@buttons&.as_json(options) || {})
         .merge(@included_targets&.as_json(options) || {})
         .select { |_k, v| v.present? }
     end

--- a/spec/factories/buttons.rb
+++ b/spec/factories/buttons.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :buttons, class: OneSignal::Buttons do
+    buttons [{id: 'option_a', text: 'Option A' }, {id: 'option_b', text: 'Option B' }]
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/onesignal/buttons_spec.rb
+++ b/spec/onesignal/buttons_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OneSignal::Buttons do
+  let(:params) do
+    { buttons:  [{id: 'option_a', text: 'Option A' }, {id: 'option_b', text: 'Option B' }]}
+  end
+
+  subject { build :buttons }
+
+  it 'creates buttons' do
+    expect(described_class.new(params)).to be_instance_of OneSignal::Buttons
+  end
+
+  fit 'serializes as json' do
+    expect(subject.as_json.deep_symbolize_keys).to include(
+      buttons: subject.buttons,
+    )
+  end
+end


### PR DESCRIPTION
This PR adds a new Buttons class to the OneSignal module to support "Action Buttons" per https://documentation.onesignal.com/docs/action-buttons