### PR TITLE
[deps]: pin faraday at >= 1.0 and bump version

### DIFF
--- a/lib/onesignal/version.rb
+++ b/lib/onesignal/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module OneSignal
-  VERSION = '0.4.1'
+  VERSION = '0.5.0'
   API_VERSION = 'v1'
 end

--- a/lib/onesignal/version.rb
+++ b/lib/onesignal/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module OneSignal
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
   API_VERSION = 'v1'
 end

--- a/onesignal-ruby.gemspec
+++ b/onesignal-ruby.gemspec
@@ -43,6 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.4'
 
   spec.add_runtime_dependency 'activesupport', '>= 5.0.0', '< 7'
-  spec.add_runtime_dependency 'faraday', '~> 0.15', '>= 0.15.4'
+  spec.add_runtime_dependency 'faraday', '~> 1.0', '>= 1.0'
   spec.add_runtime_dependency 'simple_command', '~> 0', '>= 0.0.9'
 end


### PR DESCRIPTION
In this PR I updated the faraday dependency to `~> 1.0` as previously it was pinned to an older version and causing compatibility issues in my Gemfile with other gems. 