### PR TITLE
Add email_subject to notification params

### DIFF
--- a/lib/onesignal/notification.rb
+++ b/lib/onesignal/notification.rb
@@ -6,7 +6,7 @@ require 'onesignal/notification/headings'
 module OneSignal
   class Notification
     attr_reader :contents, :headings, :template_id, :included_segments, :excluded_segments,
-                :included_targets, :send_after, :attachments, :sounds, :buttons
+                :included_targets, :email_subject, :send_after, :attachments, :sounds, :buttons
 
     def initialize **params
       unless params.include?(:contents) || params.include?(:template_id)
@@ -19,6 +19,7 @@ module OneSignal
       @included_segments = params[:included_segments]
       @excluded_segments = params[:excluded_segments]
       @included_targets  = params[:included_targets]
+      @email_subject     = params[:email_subject]
       @send_after        = params[:send_after].to_s
       @attachments       = params[:attachments]
       @filters           = params[:filters]


### PR DESCRIPTION
If you just want to send an email through OneSignal you have to set up `email_subject` because its required.

https://documentation.onesignal.com/reference/create-notification#email-content
https://documentation.onesignal.com/reference/create-notification#send-email-based-on-email-addresses---create-notification

