### PR TITLE
Fix/add email body to notification

### DIFF
--- a/lib/onesignal/notification.rb
+++ b/lib/onesignal/notification.rb
@@ -6,7 +6,8 @@ require 'onesignal/notification/headings'
 module OneSignal
   class Notification
     attr_reader :contents, :headings, :template_id, :included_segments, :excluded_segments,
-                :included_targets, :email_subject, :send_after, :attachments, :sounds, :buttons
+                :included_targets, :email_subject, :send_after, :attachments, :sounds, :buttons,
+                :email_body
 
     def initialize **params
       unless params.include?(:contents) || params.include?(:template_id)
@@ -20,6 +21,7 @@ module OneSignal
       @excluded_segments = params[:excluded_segments]
       @included_targets  = params[:included_targets]
       @email_subject     = params[:email_subject]
+      @email_body        = params[:email_body]
       @send_after        = params[:send_after].to_s
       @attachments       = params[:attachments]
       @filters           = params[:filters]

--- a/spec/onesignal/notification_spec.rb
+++ b/spec/onesignal/notification_spec.rb
@@ -25,6 +25,7 @@ describe Notification do
        Filter.country.equals('IT')]
     end
     let(:email_subject) { Faker::Lorem.sentence }
+    let(:email_body) { '<p>fake body</p>' }
     let(:sounds) { build :sounds }
     let(:targets) { IncludedTargets.new include_email_tokens: 'test', include_external_user_ids: 'test' }
 
@@ -38,7 +39,8 @@ describe Notification do
             filters: filters,
             sounds: sounds,
             included_targets: targets,
-            email_subject: email_subject
+            email_subject: email_subject,
+            email_body: email_body
     end
 
     it 'serializes as json' do
@@ -61,7 +63,8 @@ describe Notification do
         'wp_wns_sound'  => sounds.windows.as_json,
         'include_email_tokens' => targets.include_email_tokens,
         'include_external_user_ids' => targets.include_external_user_ids,
-        'email_subject' => email_subject
+        'email_subject' => email_subject,
+        'email_body' => email_body
       )
     end
   end


### PR DESCRIPTION
### Description
Fixes a bug when creating a notification with email_body

### Bug reproduction steps:
```
headings = OneSignal::Notification::Headings.new ...
contents = OneSignal::Notification::Contents.new ...
included_targets = OneSignal::IncludedTargets.new ...

notification = OneSignal::Notification.new(
  headings: headings,
  contents: contents,
  included_targets: included_targets,
  email_subject: 'my email_subject',
  email_body: '<p>my fake email body </p>'
)

OneSignal.send_notification(notification)

Traceback (most recent call last):
        8: from bin/console:34:in `<main>'
        7: from (irb):5
        6: from /Users/martin/repos/onesignal-ruby/lib/onesignal.rb:19:in `send_notification'
        5: from /Users/martin/.rvm/gems/ruby-2.7.0/gems/simple_command-0.1.0/lib/simple_command.rb:9:in `call'
        4: from /Users/martin/repos/onesignal-ruby/lib/onesignal/commands/create_notification.rb:11:in `call'
        3: from /Users/martin/repos/onesignal-ruby/lib/onesignal/client.rb:23:in `create_notification'
        2: from /Users/martin/repos/onesignal-ruby/lib/onesignal/client.rb:67:in `post'
        1: from /Users/martin/repos/onesignal-ruby/lib/onesignal/client.rb:82:in `handle_errors'
OneSignal::Client::ApiError  (Message Email body can not be blank)
```

With this PR:
```
 => #<OneSignal::Responses::Notification:0x00007ffb801be648 ...}>
```

### Documentation
<img width="1056" alt="Screen Shot 2021-05-14 at 18 10 21" src="https://user-images.githubusercontent.com/50113670/118331990-c58d2380-b4df-11eb-99e6-8c70af4859e3.png">


 
 