### PR TITLE
Support for deleting a player; and for external_player_id (alt PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Support for deleting a Player
+- Support for external_player_id
+
+
+## [Unreleased]
+### Added
 - Support for icons thanks to [@mtayllan] ([#33](https://github.com/mikamai/onesignal-ruby/pull/33))
 
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ player = OneSignal.fetch_player(player_id)
 # => #<OneSignal::Responses::Player>
 ```
 
+### Delete players
+You can delete a single player by its ID.
+```ruby
+OneSignal.delete_player(player_id)
+#<OneSignal::Responses::Player:0x000056062f397d18 @attributes={}>
+```
+
 ### Filters
 
 Filters can be created with a simple DSL. It closely matches the [JSON reference](https://documentation.onesignal.com/reference#section-send-to-users-based-on-filters), with a few touches of syntax

--- a/fixtures/vcr_cassettes/os-delete-player.yml
+++ b/fixtures/vcr_cassettes/os-delete-player.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://onesignal.com/api/v1/players/?app_id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic test
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 Jun 2018 15:30:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d162ae07cbc70fafa075f6d10a6694cc61530199858; expires=Fri, 28-Jun-19
+        15:30:58 GMT; path=/; domain=.onesignal.com; HttpOnly
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - 768dd4da-9f24-4a93-8a1b-3efbc3bf22b2
+      Access-Control-Allow-Headers:
+      - SDK-Version
+      Etag:
+      - W/"cee038b261c95e403233f1ada96658e3"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.029141'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 5.3.2
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4321329ccab1430a-MXP
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":8,"offset":0,"limit":300,"players":[{"id":"14c8141f-d57d-4652-8911-960a00ff14fa","identifier":"52812f0ca9b3cc1c1f6a13fd1467c3a2a9f7ef3db5ee56cb951b00fb6bb78665","session_count":10,"language":"it","timezone":7200,"game_version":"1","device_os":"11.4","device_type":0,"device_model":"iPhone10,5","ad_id":"7A30EDB9-A4EA-404E-BA5E-2AEA86C74AA7","tags":{},"last_active":1530184068,"playtime":1219,"amount_spent":0.0,"created_at":1530177751,"invalid_identifier":false,"badge_count":0,"sdk":"020805","test_type":1,"ip":null},{"id":"16c0eee0-edc0-4630-8792-1c432a2e7da1","identifier":null,"session_count":2,"language":"en","timezone":7200,"game_version":"1","device_os":"7.1.2","device_type":1,"device_model":"MotoG3","ad_id":null,"tags":{},"last_active":1530192672,"playtime":0,"amount_spent":0.0,"created_at":1530192553,"invalid_identifier":true,"badge_count":0,"sdk":"030901","test_type":null,"ip":null},{"id":"066e3db6-1ed1-49f0-9340-624327e3faf8","identifier":null,"session_count":1,"language":"en","timezone":7200,"game_version":"1","device_os":"7.1.2","device_type":1,"device_model":"MotoG3","ad_id":null,"tags":{},"last_active":1530193737,"playtime":0,"amount_spent":0.0,"created_at":1530193737,"invalid_identifier":true,"badge_count":0,"sdk":"030901","test_type":null,"ip":null},{"id":"cf435718-f137-4fd8-ba43-b9ada7e88846","identifier":null,"session_count":1,"language":"en","timezone":7200,"game_version":"1","device_os":"7.1.2","device_type":1,"device_model":"MotoG3","ad_id":null,"tags":{},"last_active":1530194294,"playtime":0,"amount_spent":0.0,"created_at":1530194294,"invalid_identifier":true,"badge_count":0,"sdk":"030901","test_type":null,"ip":null},{"id":"ba4b2ab3-cc89-4bd6-8c1a-9f69e7a2aa55","identifier":null,"session_count":1,"language":"en","timezone":7200,"game_version":"1","device_os":"7.1.2","device_type":1,"device_model":"MotoG3","ad_id":null,"tags":{},"last_active":1530197017,"playtime":0,"amount_spent":0.0,"created_at":1530197017,"invalid_identifier":true,"badge_count":0,"sdk":"030901","test_type":null,"ip":null},{"id":"152c5092-beb7-4b54-a0c0-168460ff41c0","identifier":null,"session_count":1,"language":"en","timezone":0,"game_version":"1","device_os":"8.1.0","device_type":1,"device_model":"Android
+        SDK built for x86","ad_id":null,"tags":{},"last_active":1530198026,"playtime":0,"amount_spent":0.0,"created_at":1530198026,"invalid_identifier":true,"badge_count":0,"sdk":"030901","test_type":null,"ip":null},{"id":"16421e68-fa8f-4072-82db-2d2d1765c317","identifier":null,"session_count":1,"language":"en","timezone":0,"game_version":"1","device_os":"8.1.0","device_type":1,"device_model":"Android
+        SDK built for x86","ad_id":null,"tags":{},"last_active":1530198244,"playtime":0,"amount_spent":0.0,"created_at":1530198244,"invalid_identifier":true,"badge_count":0,"sdk":"030901","test_type":null,"ip":null},{"id":"e818b09c-3eca-41be-b0ee-8379cab19d93","identifier":null,"session_count":1,"language":"en","timezone":0,"game_version":"1","device_os":"8.1.0","device_type":1,"device_model":"Android
+        SDK built for x86","ad_id":null,"tags":{},"last_active":1530199447,"playtime":0,"amount_spent":0.0,"created_at":1530199447,"invalid_identifier":true,"badge_count":0,"sdk":"030901","test_type":null,"ip":null}]}'
+    http_version: 
+  recorded_at: Thu, 28 Jun 2018 15:30:58 GMT
+recorded_with: VCR 4.0.0

--- a/lib/onesignal.rb
+++ b/lib/onesignal.rb
@@ -59,6 +59,13 @@ module OneSignal
       Responses::Player.from_json fetched.body
     end
 
+    def delete_player player_id
+      return unless OneSignal.config.active
+
+      fetched = Commands::DeletePlayer.call player_id
+      Responses::Player.from_json fetched.body
+    end
+
     def fetch_players
       return unless OneSignal.config.active
 

--- a/lib/onesignal/client.rb
+++ b/lib/onesignal/client.rb
@@ -41,6 +41,10 @@ module OneSignal
       get "players/#{player_id}"
     end
 
+    def delete_player player_id
+      delete "players/#{player_id}"
+    end
+
     def csv_export extra_fields: nil, last_active_since: nil, segment_name: nil
       post "players/csv_export?app_id=#{@app_id}", 
         extra_fields: extra_fields, 
@@ -54,6 +58,15 @@ module OneSignal
       body = payload.as_json.delete_if { |_, v| v.nil? }
       body['app_id'] = @app_id
       body
+    end
+
+    def delete url
+      res = @conn.delete do |req|
+        req.url url, app_id: @app_id
+        req.headers['Authorization'] = "Basic #{@api_key}"
+      end
+
+      handle_errors res
     end
 
     def post url, body

--- a/lib/onesignal/commands/delete_player.rb
+++ b/lib/onesignal/commands/delete_player.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module OneSignal
+  module Commands
+    class DeletePlayer < BaseCommand
+      def initialize player_id
+        @player_id = player_id
+      end
+
+      def call
+        client.delete_player @player_id
+      end
+    end
+  end
+end

--- a/lib/onesignal/notification.rb
+++ b/lib/onesignal/notification.rb
@@ -7,7 +7,7 @@ module OneSignal
   class Notification
     attr_reader :contents, :headings, :template_id, :included_segments, :excluded_segments,
                 :included_targets, :email_subject, :send_after, :attachments, :sounds, :buttons,
-                :email_body, :icons
+                :email_body, :icons, :external_id
 
     def initialize **params
       unless params.include?(:contents) || params.include?(:template_id)
@@ -28,6 +28,7 @@ module OneSignal
       @sounds            = params[:sounds]
       @buttons           = params[:buttons]
       @icons             = params[:icons]
+      @external_id       = params[:external_id]
     end
 
     def as_json options = {}

--- a/spec/api_calls_spec.rb
+++ b/spec/api_calls_spec.rb
@@ -63,6 +63,15 @@ describe 'Live API Testing', remote: true do
     end
   end
 
+  it 'deletes one player by id' do
+    VCR.use_cassette('os-delete-player', :record => :new_episodes) do
+      player = OneSignal.delete_player @player_id
+      expect(player).to be_instance_of OneSignal::Responses::Player
+      expect(player.id).to eq @player_id
+    end
+  end
+
+
   context 'with keys' do
     around do |example|
       OneSignal.config.app_id = app_id


### PR DESCRIPTION
Added support for deleting a Player (required adding http DELETE command support)
Added support for `external_player_id`

Remember to assign the pull request to a [CODEOWNER](../CODEOWNERS) for review.

**ALWAYS** open PRs targeting [develop](https://github.com/mikamai/onesignal-ruby/tree/develop), as it is our mainline branch. Master is only used to cut stable releases.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have added tests for each new piece of code I added, or updated existing tests if I changed some existing code
- [x] I have added the relevant entry in the `Unreleased` section of the CHANGELOG file 
- [x] I have made corresponding changes to the documentation (namely the README file)
