### PR TITLE
Add priority as notification parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add priority as notification parameter ([#36](https://github.com/mikamai/onesignal-ruby/pull/36))
 
 ## [0.6.0] - 2021-10-21
 ### Added

--- a/lib/onesignal/notification.rb
+++ b/lib/onesignal/notification.rb
@@ -23,6 +23,7 @@ module OneSignal
       @email_subject     = params[:email_subject]
       @email_body        = params[:email_body]
       @send_after        = params[:send_after].to_s
+      @priority          = params[:priority]
       @attachments       = params[:attachments]
       @filters           = params[:filters]
       @sounds            = params[:sounds]

--- a/spec/onesignal/notification_spec.rb
+++ b/spec/onesignal/notification_spec.rb
@@ -18,6 +18,7 @@ describe Notification do
   context 'json' do
     let(:segments) { [build(:segment), build(:segment)] }
     let(:time) { Time.now }
+    let(:priority) { 10 }
     let(:filters) do
       [Filter.last_session.lesser_than(2).hours_ago!,
        Filter.session_count.equals(5),
@@ -37,6 +38,7 @@ describe Notification do
             included_segments: segments,
             excluded_segments: segments,
             send_after: time,
+            priority: priority,
             filters: filters,
             sounds: sounds,
             included_targets: targets,
@@ -50,6 +52,7 @@ describe Notification do
         'contents' => contents.as_json,
         'headings' => headings.as_json,
         'send_after' => time.to_s,
+        'priority' => priority,
         'included_segments' => segments.as_json,
         'excluded_segments' => segments.as_json,
         'data' => subject.attachments.data.as_json,


### PR DESCRIPTION
Add priority as notification parameter according to OneSignal API docs
https://documentation.onesignal.com/reference/create-notification#delivery

Further improvements could include other delivery options as well