### PR TITLE
Bump activesupport version upto 7

### DIFF
--- a/onesignal-ruby.gemspec
+++ b/onesignal-ruby.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '~> 4.0', '>= 4.0.0'
   spec.add_development_dependency 'webmock', '~> 3.4'
 
-  spec.add_runtime_dependency 'activesupport', '>= 5.0.0', '< 7'
+  spec.add_runtime_dependency 'activesupport', '>= 5.0.0', '< 8'
   spec.add_runtime_dependency 'faraday', '~> 1.0', '>= 1.0'
   spec.add_runtime_dependency 'simple_command', '~> 0', '>= 0.0.9'
 end


### PR DESCRIPTION
Recently rails 7 was released. Please merge this change so it will be able to update rails to the latest version with the onesignal-ruby gem.