### PR TITLE
Bump activesupport version upto 7

### DIFF
--- a/lib/onesignal.rb
+++ b/lib/onesignal.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/version'
+require 'active_support/isolated_execution_state' if ActiveSupport::VERSION::MAJOR == 7
 require 'active_support/core_ext/string'
 require 'active_support/json'
 require 'onesignal/version'

--- a/onesignal-ruby.gemspec
+++ b/onesignal-ruby.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '~> 4.0', '>= 4.0.0'
   spec.add_development_dependency 'webmock', '~> 3.4'
 
-  spec.add_runtime_dependency 'activesupport', '>= 5.0.0', '< 7'
+  spec.add_runtime_dependency 'activesupport', '>= 5.0.0', '< 8'
   spec.add_runtime_dependency 'faraday', '~> 1.0', '>= 1.0'
   spec.add_runtime_dependency 'simple_command', '~> 0', '>= 0.0.9'
 end


### PR DESCRIPTION
Hello!
Tests from #37 have been fixed. Please merge this.
related to [issue#39](https://github.com/mikamai/onesignal-ruby/issues/39)