### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ If you want to send a notification only to specific targets (a particular user's
 pass a `OneSignal::IncludedTargets` to the notification object.
 See [the official documentation](https://documentation.onesignal.com/reference#section-send-to-specific-devices) for a list of available params.
 ```ruby
-included_targets = OneSignal::IncludedTargets.new(include_player_ids: 'test-id-12345')
+included_targets = OneSignal::IncludedTargets.new(include_player_ids: ['test-id-12345'])
 OneSignal::Notification.new(included_targets: included_targets)
 ```
 


### PR DESCRIPTION
This pull request improves an example in the docs that throws the following error when querying the `included_targets`:

For example, the following query:
```ruby
OneSignal::Notification.new(included_targets: included_targets, heading: headings, contents: contents)
```
Leads to the following error below:
```bash
OneSignal::Client::ApiError (include_external_user_ids must be an array)
```


## Type of change

- [X] Improvement of the docs (all other types did not fit)


## Checklist

- [X] I have made corresponding changes to the documentation (namely the README file)
